### PR TITLE
Área de Busca por Pesquisadores

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'simcc.uesc.br',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -43,6 +43,7 @@
   --radius-xl: calc(var(--radius) + 4px);
 
   --color-search-selection: var(--search-selection);
+  --color-card-selection: var(--card-selection);
 
   --color-eng-primary: var(--eng-primary);
   --color-eng-secondary: var(--eng-secondary);
@@ -84,6 +85,7 @@
   --sidebar-ring: oklch(0.65 0.17 259.3);
 
   --search-selection: oklch(0.65 0.17 259.3);
+  --card-selection: oklch(0.99 0 0);
 
   --eng-primary: #559FB8;
   --eng-secondary: #024A60;

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -42,10 +42,12 @@ export default function RootLayout({
         <SidebarProvider>
           <AppSidebar/>
           <SidebarInset>
-            <AppPageHeader/>
-            <main>
-              {children}
-            </main>
+            <div className="w-full pb-8 px-4">
+              <AppPageHeader/>
+              <main>
+                {children}
+              </main>
+            </div>
           </SidebarInset>
         </SidebarProvider>
       </body>

--- a/front/src/app/pesquisadores/page.tsx
+++ b/front/src/app/pesquisadores/page.tsx
@@ -1,9 +1,11 @@
 import { HeroPesquisadores } from "@/components/Hero";
+import { PesquisadoresSugeridosArea } from "@/components/PesquisadoresSugeridos";
 
 export default function PesquisadoresPage() {
   return (
-    <div className="font-sans">
+    <div className="">
         <HeroPesquisadores/>
+        <PesquisadoresSugeridosArea/>
     </div>
   );
 }

--- a/front/src/components/CardPesquisador.tsx
+++ b/front/src/components/CardPesquisador.tsx
@@ -7,10 +7,10 @@ const CardPesquisador = ({nome, instituicao, url}:{
 }) => {
     return (
         <div className="cursor-pointer h-80 w-60 rounded border border-border hover:bg-card-selection hover:shadow-sm bg-white py-6 flex flex-col items-center transition-all">
-            <div className="bg-neutral-100 border border-border rounded h-36 aspect-square flex justify-center items-center">
+            <div className="overflow-hidden relative bg-neutral-100 border border-border rounded h-36 aspect-square flex justify-center items-center">
                 {!url && <User className="text-neutral-600" size={"96"}/>}
                 {url && 
-                <Image alt="" src={url} fill={true}/>
+                <Image alt="" src={url} fill={true} className="object-cover" unoptimized={true}/>
                 }
             </div>
             <div className="flex flex-col w-full px-8 pt-1">

--- a/front/src/components/CardPesquisador.tsx
+++ b/front/src/components/CardPesquisador.tsx
@@ -1,0 +1,34 @@
+import { User } from "lucide-react";
+import Image from "next/image";
+const CardPesquisador = ({nome, instituicao, url}:{
+    nome: string,
+    instituicao: string
+    url?:string
+}) => {
+    return (
+        <div className="cursor-pointer h-80 w-60 rounded border border-border hover:bg-card-selection hover:shadow-sm bg-white py-6 flex flex-col items-center transition-all">
+            <div className="bg-neutral-100 border border-border rounded h-36 aspect-square flex justify-center items-center">
+                {!url && <User className="text-neutral-600" size={"96"}/>}
+                {url && 
+                <Image alt="" src={url} fill={true}/>
+                }
+            </div>
+            <div className="flex flex-col w-full px-8 pt-1">
+                <div className="min-h-[2.5rem] flex items-end">
+                <p className="text-sm font-medium leading-tight line-clamp-2">
+                    {nome}
+                </p>
+                </div>
+
+                <div className="w-full h-1 bg-eng-primary" />
+
+                <p className="text-xs text-left font-normal line-clamp-2">
+                {instituicao}
+                </p>
+            </div>
+
+        </div>
+    );
+}
+
+export { CardPesquisador }

--- a/front/src/components/Hero.tsx
+++ b/front/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import { SearchBar } from "@/components/SearchBar";
 
 const HeroEmpresas = () => {
   return (
-    <section className="pt-20 pb-16">
+    <section className="pt-20">
       <div className="container flex flex-col items-center text-center gap-10">
         
         <h1 className="text-4xl font-semibold lg:text-5xl max-w-3xl leading-tight">
@@ -23,7 +23,7 @@ const HeroEmpresas = () => {
 
 const HeroPesquisadores = () => {
   return (
-    <section className="pt-20 pb-16">
+    <section className="pt-20">
       <div className="container flex flex-col items-center text-center gap-10">
         
         <h1 className="text-4xl font-semibold lg:text-5xl max-w-3xl leading-tight">

--- a/front/src/components/PesquisadoresSugeridos.tsx
+++ b/front/src/components/PesquisadoresSugeridos.tsx
@@ -1,0 +1,39 @@
+import { CardPesquisador } from "./CardPesquisador";
+
+
+const PesquisadoresSugeridosArea = () => {
+    return (
+        <div className="w-full mt-12 px-6">
+            <div className="bg-neutral-50 rounded border border-border px-6 pb-6 pt-3">
+                <p className="ml-3 pb-3 font-light text-neutral-600">Pesquisadores encontrados</p>
+                <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(15rem,1fr))] justify-items-center">
+                    <CardPesquisador nome="Eduardo Martins da Silva" instituicao="USP" />
+                    <CardPesquisador nome="Carolina Rodrigues Albuquerque" instituicao="UFRJ" />
+                    <CardPesquisador nome="Felipe Takashi Yamamoto" instituicao="UNICAMP" />
+                    <CardPesquisador nome="Mariana Gomes Azevedo" instituicao="UFSC" />
+                    <CardPesquisador nome="André Luiz Coutinho" instituicao="UFMG" />
+                    <CardPesquisador nome="Beatriz Karolina Martins" instituicao="PUC-Rio" />
+                    <CardPesquisador nome="Ricardo Vieira Rocha" instituicao="ITA" />
+                    <CardPesquisador nome="Fernanda Pereira Oliveira" instituicao="UNESP" />
+                    <CardPesquisador nome="João Henrique Farias" instituicao="UFRGS" />
+                    <CardPesquisador nome="Laura Santos Antunes" instituicao="UFRN" />
+                    <CardPesquisador nome="Gabriel Castro Mendes" instituicao="UFPE" />
+                    <CardPesquisador nome="Natália Ribeiro Pires" instituicao="UFG" />
+                    <CardPesquisador nome="Rafael Barbosa Tavares" instituicao="UFBA" />
+                    <CardPesquisador nome="Sofia Duarte Moreira" instituicao="MIT" />
+                    <CardPesquisador nome="Lucas Matheus Fonseca" instituicao="ETH Zürich" />
+                </div>
+            </div>
+        </div>
+
+    );
+
+}
+
+const PesquisadoresSugeridosCard = () => {
+    return (
+        <></>
+    );
+}
+
+export {PesquisadoresSugeridosArea, PesquisadoresSugeridosCard };

--- a/front/src/components/PesquisadoresSugeridos.tsx
+++ b/front/src/components/PesquisadoresSugeridos.tsx
@@ -1,13 +1,12 @@
 import { CardPesquisador } from "./CardPesquisador";
-
-
+    
 const PesquisadoresSugeridosArea = () => {
     return (
         <div className="w-full mt-12 px-6">
             <div className="bg-neutral-50 rounded border border-border px-6 pb-6 pt-3">
                 <p className="ml-3 pb-3 font-light text-neutral-600">Pesquisadores encontrados</p>
                 <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(15rem,1fr))] justify-items-center">
-                    <CardPesquisador nome="Eduardo Martins da Silva" instituicao="USP" />
+                    <CardPesquisador nome="Eduardo Martins da Silva" instituicao="USP" url="https://simcc.uesc.br/v3/api/ResearcherData/Image?researcher_id=4d98bfd6-fe1c-4580-9652-42f84d807c76"/>
                     <CardPesquisador nome="Carolina Rodrigues Albuquerque" instituicao="UFRJ" />
                     <CardPesquisador nome="Felipe Takashi Yamamoto" instituicao="UNICAMP" />
                     <CardPesquisador nome="Mariana Gomes Azevedo" instituicao="UFSC" />


### PR DESCRIPTION
# PR -  Área de Busca por Pesquisadores

## Descrição
Esse PR adiciona o modelo inicial dos cards dos pesquisadores e a área de busca deles, apenas de maneira visual, sem funcionalidade prática de busca ainda.

## O que esse PR aplica
- [ ] Documentação atualizada
- [ ] Insere dependências e documenta
- [ ] Cria testes de execução
- [X] Adiciona nova feature
- [ ] Altera arquitetura do projeto

## Como Testar
Igual a rodar o ambiente de desenvolvimento de #3 com 
```
docker compose up --build
```
Em seguida, acessar o localhost na porta configurada no .env

>[!WARNING]
> Apenas um pesquisador com foto apenas para fins de demonstração. Nomes de pesquisadores falsos foram inseridos para teste
<img width="1861" height="957" alt="image" src="https://github.com/user-attachments/assets/6407d904-e0e5-449e-a0a9-219f04ecb894" />




## Dependências instaladas
Nenhuma

